### PR TITLE
Colab example: scale down html display output to 50% after the html file is read

### DIFF
--- a/guides/first-pipeline/colab.ipynb
+++ b/guides/first-pipeline/colab.ipynb
@@ -575,7 +575,7 @@
         }
       ],
       "source": [
-        "from IPython.display import HTML, IFrame\n",
+        "from IPython.display import HTML\n",
         "# We scale down the plot to 50% for better readability on Colab. You can plug in whatever you'd like.\n",
         "# Either HTML or IFrame should work.\n",
         "display(HTML(open('pipeline.html').read().replace(\"100%\", \"50%\")))"

--- a/guides/first-pipeline/colab.ipynb
+++ b/guides/first-pipeline/colab.ipynb
@@ -30,8 +30,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Installing packages with fixed versions for colab\n",
             "\u001b[K     |████████████████████████████████| 45 kB 927 kB/s \n",
@@ -88,8 +88,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Loading examples...\n",
             "Local copy does not exist...\n",
@@ -270,16 +270,16 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Loading pipeline...\n",
             "Plot saved at: pipeline.html\n"
           ]
         },
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\r  0%|          | 0/5 [00:00<?, ?it/s]\r100%|██████████| 5/5 [00:00<00:00, 7881.07it/s]\n"
           ]
@@ -318,11 +318,7 @@
       },
       "outputs": [
         {
-          "output_type": "display_data",
           "data": {
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ],
             "text/html": [
               "<!DOCTYPE html>\n",
               "<html>\n",
@@ -569,14 +565,20 @@
               "</script>\n",
               "\n",
               "</html>"
+            ],
+            "text/plain": [
+              "<IPython.core.display.HTML object>"
             ]
           },
-          "metadata": {}
+          "metadata": {},
+          "output_type": "display_data"
         }
       ],
       "source": [
         "from IPython.display import HTML, IFrame\n",
-        "display(HTML('pipeline.html')) # Either HTML or IFrame should work"
+        "# We scale down the plot to 50% for better readability on Colab. You can plug in whatever you'd like.\n",
+        "# Either HTML or IFrame should work.\n",
+        "display(HTML(open('pipeline.html').read().replace(\"100%\", \"50%\")))"
       ]
     },
     {
@@ -628,8 +630,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Loading pipeline...\n",
             "name             Ran?      Elapsed (s)    Percentage\n",
@@ -642,8 +644,8 @@
           ]
         },
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\r  0%|          | 0/5 [00:00<?, ?it/s]\rBuilding task '1-get':   0%|          | 0/5 [00:00<?, ?it/s]\n",
             "\rExecuting:   0%|          | 0/6 [00:00<?, ?cell/s]\u001b[A\n",
@@ -728,8 +730,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "1-get.html\n",
             "2-profile-raw.html\n",
@@ -795,14 +797,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "397"
             ]
           },
+          "execution_count": 8,
           "metadata": {},
-          "execution_count": 8
+          "output_type": "execute_result"
         }
       ],
       "source": [
@@ -862,8 +864,8 @@
       },
       "outputs": [
         {
-          "output_type": "stream",
           "name": "stdout",
+          "output_type": "stream",
           "text": [
             "Loading pipeline...\n",
             "name             Ran?      Elapsed (s)    Percentage\n",
@@ -876,8 +878,8 @@
           ]
         },
         {
-          "output_type": "stream",
           "name": "stderr",
+          "output_type": "stream",
           "text": [
             "\r  0%|          | 0/3 [00:00<?, ?it/s]\rBuilding task '3-clean':   0%|          | 0/3 [00:00<?, ?it/s]\n",
             "\rExecuting:   0%|          | 0/9 [00:00<?, ?cell/s]\u001b[A\n",
@@ -933,14 +935,14 @@
       },
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "381"
             ]
           },
+          "execution_count": 10,
           "metadata": {},
-          "execution_count": 10
+          "output_type": "execute_result"
         }
       ],
       "source": [


### PR DESCRIPTION
Patches #41,

Changes:
```python
from IPython.display import HTML, IFrame
# We scale down the plot to 50% for better readability on Colab. You can plug in whatever you'd like.
# Either HTML or IFrame should work.
display(HTML(open('pipeline.html').read().replace("100%", "50%")))
```
Please let me know if the wording in the comments can be any way better.