### PR TITLE
Fix broken links in the serialization guide

### DIFF
--- a/guides/serialization/README.ipynb
+++ b/guides/serialization/README.ipynb
@@ -1117,7 +1117,7 @@
                 "\n",
                 "Configuring a `serializer` and `unserializer` in your `pipeline.yaml` is optional, but it helps you quickly generate a fully in-memory pipeline for serving predictions.\n",
                 "\n",
-                "If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/user-guide/deployment.html#online-service-api).\n",
+                "If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/deployment/online.html).\n",
                 "\n",
                 "For a complete example showing how to manage a training and a serving pipeline, and deploy it as a Flask API, [click here](https://github.com/ploomber/projects/tree/master/templates/ml-online)."
             ]

--- a/guides/serialization/README.md
+++ b/guides/serialization/README.md
@@ -317,6 +317,6 @@ cat output/final_dict.json
 
 Configuring a `serializer` and `unserializer` in your `pipeline.yaml` is optional, but it helps you quickly generate a fully in-memory pipeline for serving predictions.
 
-If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/user-guide/deployment.html#online-service-api).
+If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/deployment/online.html).
 
 For a complete example showing how to manage a training and a serving pipeline, and deploy it as a Flask API, [click here](https://github.com/ploomber/projects/tree/master/templates/ml-online).

--- a/guides/serialization/_source.md
+++ b/guides/serialization/_source.md
@@ -153,6 +153,6 @@ cat output/final_dict.json
 
 Configuring a `serializer` and `unserializer` in your `pipeline.yaml` is optional, but it helps you quickly generate a fully in-memory pipeline for serving predictions.
 
-If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/user-guide/deployment.html#online-service-api).
+If you want to learn more about in-memory pipelines, check out the [following guide](https://docs.ploomber.io/en/latest/deployment/online.html).
 
 For a complete example showing how to manage a training and a serving pipeline, and deploy it as a Flask API, [click here](https://github.com/ploomber/projects/tree/master/templates/ml-online).


### PR DESCRIPTION
Fix broken links in the serialization guide
https://docs.ploomber.io/en/latest/user-guide/deployment.html#online-service-api -> https://docs.ploomber.io/en/latest/deployment/online.html