### PR TITLE
Updates headers and notes.

### DIFF
--- a/guides/cloud-notebook-parametrized/README.ipynb
+++ b/guides/cloud-notebook-parametrized/README.ipynb
@@ -60,9 +60,15 @@
     "```python\n",
     "# PARAMETERS\n",
     "n_estimators = 1\n",
-    "```\n",
-    "\n",
-    "**Important:** You must add the comment `# PARAMETERS` in the cell. With this, Ploomber will be able to identify that those parameter will be used during the execution.\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66facde1-5780-4e35-933c-9398be195f6f",
+   "metadata": {},
+   "source": [
+    "> **Important:** You must add the comment `# PARAMETERS` in the cell. With this, Ploomber will be able to identify that those parameter will be used during the execution.\n",
     "\n",
     "Next, ensure that such parameters are used in the notebook's body. Ploomber Cloud will change these values at runtime.\n",
     "\n",
@@ -73,9 +79,15 @@
     "    n_estimators: [1, 5, 10, 20]\n",
     "```\n",
     "\n",
-    "Your notebook can have more than one parameter. In such case, Ploomber Cloud will run the notebook with all possible combinations.\n",
-    "\n",
-    "**Note:** the raw cell must be a valid YAML string. YAML is a data serialization language that is often used for writing configuration files. It usually follows a simple format to list attributes. You can read more about YAML [here](https://en.wikipedia.org/wiki/YAML)."
+    "Your notebook can have more than one parameter. In such case, Ploomber Cloud will run the notebook with all possible combinations."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fb2a20f-9d7a-4a1d-b5b0-2aed091954f4",
+   "metadata": {},
+   "source": [
+    "> **Note:** the raw cell must be a valid YAML string. YAML is a data serialization language that is often used for writing configuration files. It usually follows a simple format to list attributes. You can read more about YAML [here](https://en.wikipedia.org/wiki/YAML)."
    ]
   },
   {
@@ -370,9 +382,15 @@
    "id": "b84abbdb-be71-4d82-9259-8867e8c000d7",
    "metadata": {},
    "source": [
-    "Note that we're using the identifier printed when we submitted the notebook.\n",
-    "\n",
-    "> For a better understanding of the previous cells, you can read more details about **execution monitoring** and **downloading results** in the [previous guide](../cloud-notebook-simple/README.ipynb)."
+    "Note that we're using the identifier printed when we submitted the notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f29591c8-c4ad-45db-933a-d6948010c17c",
+   "metadata": {},
+   "source": [
+    "> For a better understanding of the previous cells, you can read more details about **execution monitoring** and **downloading results** in the [previous guide](../cloud/cloud-notebook-simple.html)."
    ]
   },
   {
@@ -670,10 +688,15 @@
     "\n",
     "```sh\n",
     "curl https://raw.githubusercontent.com/ploomber/projects/master/guides/cloud-notebook-parametrized/notebooks/resources.ipynb -o notebooks/resources.ipynb\n",
-    "```\n",
-    "\n",
-    "\n",
-    "**Note:** The free community plan is capped to 2 CPUS and 4GiB of memory and no GPUs. If you need more resources, you can subscribe to the Teams plan. If you're a student or researcher, join our [Slack](https://ploomber.io/community) and we'll lift the restrictions."
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "698af29a-0ae9-498d-9eb6-d8e63d66652f",
+   "metadata": {},
+   "source": [
+    "> **Note:** The free community plan is capped to 2 CPUS and 4GiB of memory and no GPUs. If you need more resources, you can subscribe to the Teams plan. If you're a student or researcher, join our [Slack](https://ploomber.io/community) and we'll lift the restrictions."
    ]
   },
   {


### PR DESCRIPTION
- I've ensured all headers in the `guides/cloud-notebook-parametrized/README.ipynb` notebooks are H2 headers.
- I've verified the image in this notebook and updated the reference to the previous guide.
- I've solved the notes issue by adding the `> text`-notes in new markdown cells.

I think that most of the rendering issues may come from rtd, since I can render without any problem from Jupyter both guides.