### PR TITLE
Fixes img route in cloud notebook

### DIFF
--- a/guides/cloud-notebooks-getting-started/README.ipynb
+++ b/guides/cloud-notebooks-getting-started/README.ipynb
@@ -55,7 +55,7 @@
     "For this simple example, we will use a notebook that draws random numbers with `numpy` and plots them with `matplotlib`. \n",
     "\n",
     "> To make it more interesting, we will use these random numbes to estimate a value of pi using the [Monte Carlo Method](https://en.wikipedia.org/wiki/Monte_Carlo_method). (This is just to make a simple example more interesting, but in any case, the important part is just to see how this example will allow you to run the notebook directly in Ploober Cloud.) \n",
-    "> <center><img src=\"https://github.com/ploomber/projects/raw/master/guides/cloud-notebook-simple/plot.png\" width=\"70%\"></center>\n",
+    "> <center><img src=\"https://raw.githubusercontent.com/ploomber/projects/master/guides/cloud-notebooks-getting-started/plot.png\" width=\"70%\"></center>\n",
     "\n",
     "First, you will need to download the sample notebook we have prepared to your local folder. To do so, you just need to run the following command in your terminal:\n",
     "\n",


### PR DESCRIPTION
[This section](https://docs.ploomber.io/en/latest/cloud/cloud-notebooks-getting-started.html#Notebook-submission-to-Ploomber-Cloud) is not rendering the example image properly.

I added the [raw route](https://raw.githubusercontent.com/ploomber/projects/master/guides/cloud-notebooks-getting-started/plot.png) from GitHub.